### PR TITLE
API error responses can sometimes be an array of errors

### DIFF
--- a/lib/Shopify/Api/Client.php
+++ b/lib/Shopify/Api/Client.php
@@ -274,7 +274,7 @@ class Client
 
         if (isset($response->errors)) {
             // Errors can sometimes be an array. Take this into account.
-            $error = is_string($response->errors) ? $response->errors : current($response->errors);
+            $error = is_string($response->errors) ? $response->errors : current(array_flatten($response->errors));
             throw new \RuntimeException($error);
         }
 

--- a/lib/Shopify/Api/Client.php
+++ b/lib/Shopify/Api/Client.php
@@ -273,8 +273,9 @@ class Client
         $response = json_decode($response);
 
         if (isset($response->errors)) {
-
-            throw new \RuntimeException($response->errors);
+            // Errors can sometimes be an array. Take this into account.
+            $error = is_string($response->errors) ? $response->errors : current($response->errors);
+            throw new \RuntimeException($error);
         }
 
         return $response;


### PR DESCRIPTION
Take this into account, when catching/throwing api error as a `RuntimeException`.
